### PR TITLE
Extract invitation routes into router module

### DIFF
--- a/routes/invitations.js
+++ b/routes/invitations.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const fsp = require('fs/promises');
+
+const {
+  INVITES_DIR,
+  ensureInvitesDirectory,
+  ensureUniqueSlug,
+  renderInvitationHtml,
+  validatePayload,
+  buildBaseSlug,
+  sanitizeSlug,
+  saveInvitation,
+  isSafeSlug
+} = require('../lib/invitations');
+
+const router = express.Router();
+
+router.post('/api/invitations', async (req, res) => {
+  const validation = validatePayload(req.body);
+  if (validation.error) {
+    return res.status(400).json({ error: validation.error });
+  }
+
+  const { invitation, theme, requestedSlug } = validation.data;
+  const baseSlug = buildBaseSlug(invitation);
+  const preferredSlug = requestedSlug || baseSlug;
+  const allowCurrent = requestedSlug || null;
+
+  try {
+    await ensureInvitesDirectory();
+    const slug = await ensureUniqueSlug(preferredSlug, allowCurrent, baseSlug);
+    const html = renderInvitationHtml({ invitation, theme });
+    await saveInvitation(slug, html);
+    const url = new URL(`/invite/${slug}`, `${req.protocol}://${req.get('host')}`).toString();
+    return res.status(201).json({ slug, url });
+  } catch (error) {
+    console.error('Не удалось сохранить приглашение', error);
+    return res.status(500).json({ error: 'Не удалось сохранить приглашение. Попробуйте позже.' });
+  }
+});
+
+router.get('/invite/:slug', async (req, res) => {
+  const rawSlug = req.params.slug || '';
+  const slug = sanitizeSlug(rawSlug);
+  if (!slug || !isSafeSlug(slug)) {
+    return res.status(404).send('Приглашение не найдено.');
+  }
+
+  const filePath = path.join(INVITES_DIR, slug, 'index.html');
+  try {
+    await fsp.access(filePath, fs.constants.F_OK);
+    return res.sendFile(filePath);
+  } catch (error) {
+    return res.status(404).send('Приглашение не найдено.');
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,66 +1,18 @@
 const express = require('express');
 const morgan = require('morgan');
-const path = require('path');
-const fs = require('fs');
-const fsp = require('fs/promises');
 
 const {
   ROOT_DIR,
-  INVITES_DIR,
-  ensureInvitesDirectory,
-  ensureUniqueSlug,
-  renderInvitationHtml,
-  validatePayload,
-  buildBaseSlug,
-  sanitizeSlug,
-  saveInvitation,
-  isSafeSlug
+  ensureInvitesDirectory
 } = require('./lib/invitations');
+const invitationsRouter = require('./routes/invitations');
 
 const app = express();
 
 app.use(morgan('dev'));
 app.use(express.json({ limit: '1mb' }));
 
-app.post('/api/invitations', async (req, res) => {
-  const validation = validatePayload(req.body);
-  if (validation.error) {
-    return res.status(400).json({ error: validation.error });
-  }
-
-  const { invitation, theme, requestedSlug } = validation.data;
-  const baseSlug = buildBaseSlug(invitation);
-  const preferredSlug = requestedSlug || baseSlug;
-  const allowCurrent = requestedSlug || null;
-
-  try {
-    await ensureInvitesDirectory();
-    const slug = await ensureUniqueSlug(preferredSlug, allowCurrent, baseSlug);
-    const html = renderInvitationHtml({ invitation, theme });
-    await saveInvitation(slug, html);
-    const url = new URL(`/invite/${slug}`, `${req.protocol}://${req.get('host')}`).toString();
-    return res.status(201).json({ slug, url });
-  } catch (error) {
-    console.error('Не удалось сохранить приглашение', error);
-    return res.status(500).json({ error: 'Не удалось сохранить приглашение. Попробуйте позже.' });
-  }
-});
-
-app.get('/invite/:slug', async (req, res) => {
-  const rawSlug = req.params.slug || '';
-  const slug = sanitizeSlug(rawSlug);
-  if (!slug || !isSafeSlug(slug)) {
-    return res.status(404).send('Приглашение не найдено.');
-  }
-
-  const filePath = path.join(INVITES_DIR, slug, 'index.html');
-  try {
-    await fsp.access(filePath, fs.constants.F_OK);
-    return res.sendFile(filePath);
-  } catch (error) {
-    return res.status(404).send('Приглашение не найдено.');
-  }
-});
+app.use('/', invitationsRouter);
 
 app.use(express.static(ROOT_DIR, { extensions: ['html'] }));
 


### PR DESCRIPTION
## Summary
- move the invitation API and slug routes into a dedicated Express router module
- mount the router in `server.js` while keeping static file serving and startup initialization unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd2595f4883248b6e600267c23c7d