### PR TITLE
Refactor server entrypoint and integrate Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+HOST=0.0.0.0
+PORT=3000
+DATABASE_URL=postgresql://wedding:wedding@localhost:5432/wedding
+JWT_SECRET=replace-with-secure-secret

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@
 
 ## Запуск проекта
 
-1. Установите зависимости:
+1. Скопируйте `.env.example` в `.env` и заполните значения переменных окружения.
+2. Установите зависимости:
    ```bash
    npm install
    ```
-2. Запустите сервер (Express отдаёт статические файлы и API):
+3. Поднимите PostgreSQL 15 (см. раздел ниже) и примените миграции Prisma:
+   ```bash
+   npm run prisma:migrate
+   npm run prisma:generate
+   ```
+4. Запустите сервер (Express отдаёт статические файлы и API):
    ```bash
    npm run dev
    ```
@@ -16,13 +22,56 @@
    ```bash
    npm start
    ```
-3. Откройте [http://localhost:3000](http://localhost:3000) в браузере. Конструктор и опубликованные приглашения обслуживаются одним Node.js приложением.
+5. Откройте [http://localhost:3000](http://localhost:3000) в браузере. Конструктор и опубликованные приглашения обслуживаются одним Node.js приложением.
 
 ### Совместный просмотр по сети
 
 - Убедитесь, что сервер запущен и порт 3000 открыт в файерволе.
 - Узнайте локальный IP адрес хоста (например, `192.168.0.10`).
 - Гости могут открывать приложение по адресу `http://192.168.0.10:3000` и переходить по сгенерированным ссылкам вида `http://192.168.0.10:3000/invite/<slug>`.
+
+### PostgreSQL 15 локально
+
+Самый быстрый способ запустить PostgreSQL 15 — использовать Docker:
+
+```bash
+docker run \
+  --name wedding-postgres \
+  -e POSTGRES_USER=wedding \
+  -e POSTGRES_PASSWORD=wedding \
+  -e POSTGRES_DB=wedding \
+  -p 5432:5432 \
+  -d postgres:15
+```
+
+После запуска контейнера установите переменную `DATABASE_URL` в `.env`, например:
+
+```
+DATABASE_URL=postgresql://wedding:wedding@localhost:5432/wedding
+```
+
+Примените миграции:
+
+```bash
+npm run prisma:migrate
+```
+
+При необходимости пересоберите Prisma Client:
+
+```bash
+npm run prisma:generate
+```
+
+### Подключение через DataGrip
+
+- **Host**: `localhost`
+- **Port**: `5432`
+- **Database**: `wedding`
+- **User**: `wedding`
+- **Password**: `wedding`
+- **Driver**: `PostgreSQL`
+
+После ввода параметров протестируйте подключение и сохраните его для работы с схемой и данными.
 
 ## Публикация приглашений
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.19.2",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.0",
+        "@prisma/client": "^5.14.0",
+        "dotenv": "^16.4.5"
       },
       "devDependencies": {
-        "nodemon": "^3.1.0"
+        "nodemon": "^3.1.0",
+        "prisma": "^5.14.0"
       }
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -2,19 +2,24 @@
   "name": "wedding",
   "version": "1.0.0",
   "description": "Wedding planner with invitation publishing backend",
-  "main": "server.js",
+  "main": "src/server/index.js",
   "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js"
+    "start": "node src/server/index.js",
+    "dev": "nodemon src/server/index.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@prisma/client": "^5.14.0",
+    "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "morgan": "^1.10.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.0"
+    "nodemon": "^3.1.0",
+    "prisma": "^5.14.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,68 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id                 String              @id @default(uuid())
+  email              String              @unique
+  passwordHash       String
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+  contractorProfile  ContractorProfile?
+  weddingProfile     WeddingProfile?
+  invitations        InvitationMeta[]
+}
+
+model ContractorProfile {
+  id          String   @id @default(uuid())
+  userId      String   @unique
+  user        User     @relation(fields: [userId], references: [id])
+  companyName String
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model WeddingProfile {
+  id            String   @id @default(uuid())
+  userId        String   @unique
+  user          User     @relation(fields: [userId], references: [id])
+  coupleNames   String
+  eventDate     DateTime?
+  location      String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  guests        Guest[]
+}
+
+model InvitationMeta {
+  id        String   @id @default(uuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  slug      String   @unique
+  theme     String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  guests    Guest[]
+}
+
+model Guest {
+  id                String           @id @default(uuid())
+  invitationId      String
+  invitation        InvitationMeta   @relation(fields: [invitationId], references: [id])
+  weddingProfileId  String?
+  weddingProfile    WeddingProfile?  @relation(fields: [weddingProfileId], references: [id])
+  name              String
+  email             String?
+  status            String           @default("pending")
+  createdAt         DateTime         @default(now())
+  updatedAt         DateTime         @updatedAt
+
+  @@index([invitationId])
+  @@index([weddingProfileId])
+}

--- a/server.js
+++ b/server.js
@@ -1,49 +1,16 @@
-const express = require('express');
-const morgan = require('morgan');
+const { start } = require('./src/server');
 
-const {
-  ROOT_DIR,
-  ensureInvitesDirectory
-} = require('./lib/invitations');
-const invitationsRouter = require('./routes/invitations');
-
-const app = express();
-
-app.use(morgan('dev'));
-app.use(express.json({ limit: '1mb' }));
-
-app.use('/', invitationsRouter);
-
-app.use(express.static(ROOT_DIR, { extensions: ['html'] }));
-
-app.use((err, req, res, next) => {
-  if (err instanceof SyntaxError && 'body' in err) {
-    return res.status(400).json({ error: 'Не удалось разобрать данные запроса.' });
-  }
-  return next(err);
-});
-
-app.use((err, req, res, next) => {
-  console.error('Непредвиденная ошибка сервера', err);
-  res.status(500).json({ error: 'Произошла непредвиденная ошибка.' });
-});
-
-async function start() {
-  try {
-    await ensureInvitesDirectory();
-    const port = process.env.PORT || 8000;
-    const host = process.env.HOST || '10.8.0.9';
-    app.listen(port, host, () => {
-      console.log(`Wedding server is running on http://${host}:${port}`);
-    });
-  } catch (error) {
-    console.error('Не удалось инициализировать сервер', error);
-    process.exit(1);
-  }
+async function main() {
+  await start();
 }
 
 if (require.main === module) {
-  start();
+  main().catch((error) => {
+    console.error('Не удалось инициализировать сервер', error);
+    process.exit(1);
+  });
 }
 
-module.exports = app;
+module.exports = {
+  start
+};

--- a/src/db/client.js
+++ b/src/db/client.js
@@ -1,0 +1,15 @@
+const { PrismaClient } = require('@prisma/client');
+
+let prisma;
+
+function getPrismaClient() {
+  if (!prisma) {
+    prisma = new PrismaClient();
+  }
+  return prisma;
+}
+
+module.exports = {
+  prisma: getPrismaClient(),
+  getPrismaClient
+};

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+const envPath = path.resolve(process.cwd(), '.env');
+dotenv.config({ path: envPath });
+
+function readEnv(name, fallback) {
+  const value = process.env[name];
+  if (value === undefined || value === null || String(value).trim() === '') {
+    if (fallback === undefined) {
+      throw new Error(`Environment variable ${name} is required.`);
+    }
+    return String(fallback).trim();
+  }
+  return String(value).trim();
+}
+
+const host = readEnv('HOST', '0.0.0.0');
+const portValue = readEnv('PORT', '3000');
+const port = Number(portValue);
+if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  throw new Error(`Environment variable PORT must be a valid integer between 1 and 65535. Received: ${portValue}`);
+}
+
+const databaseUrl = readEnv('DATABASE_URL');
+const jwtSecret = readEnv('JWT_SECRET');
+
+const config = {
+  env: process.env.NODE_ENV || 'development',
+  host,
+  port,
+  databaseUrl,
+  jwtSecret
+};
+
+module.exports = config;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const morgan = require('morgan');
+
+const config = require('./config');
+const {
+  ROOT_DIR,
+  ensureInvitesDirectory
+} = require('../../lib/invitations');
+const invitationsRouter = require('../../routes/invitations');
+const { prisma } = require('../db/client');
+
+const app = express();
+
+app.use(morgan('dev'));
+app.use(express.json({ limit: '1mb' }));
+app.use('/', invitationsRouter);
+app.use(express.static(ROOT_DIR, { extensions: ['html'] }));
+
+app.use((err, req, res, next) => {
+  if (err instanceof SyntaxError && 'body' in err) {
+    return res.status(400).json({ error: 'Не удалось разобрать данные запроса.' });
+  }
+  return next(err);
+});
+
+app.use((err, req, res, next) => {
+  console.error('Непредвиденная ошибка сервера', err);
+  res.status(500).json({ error: 'Произошла непредвиденная ошибка.' });
+});
+
+async function checkDatabaseConnection() {
+  try {
+    await prisma.$connect();
+    console.log('Successfully connected to the database.');
+  } catch (error) {
+    console.error('Failed to connect to the database', error);
+  }
+}
+
+async function start(options = {}) {
+  const host = options.host ?? config.host;
+  const port = options.port ?? config.port;
+
+  await ensureInvitesDirectory();
+  await checkDatabaseConnection();
+
+  return new Promise((resolve) => {
+    const server = app.listen(port, host, () => {
+      console.log(`Wedding server is running on http://${host}:${port}`);
+      resolve(server);
+    });
+  });
+}
+
+if (require.main === module) {
+  start().catch((error) => {
+    console.error('Не удалось инициализировать сервер', error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  app,
+  start
+};


### PR DESCRIPTION
## Summary
- move the Express application setup into `src/server`, export the app/start helpers, and keep the root `server.js` as a thin CLI wrapper
- add centralized configuration loading with environment validation, a shared Prisma client, and the initial Prisma schema for core domain tables
- refresh scripts, environment examples, and docs to cover the new entrypoint along with PostgreSQL 15 setup and migration commands

## Testing
- npm install *(fails: registry returned 403 for @prisma/client in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe013483c8324aeea3d1d34352e43