### PR TITLE
Add API client module and role-based routing guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   </div>
   <main id="app" role="main"></main>
   <script src="data.js"></script>
+  <script src="public/frontend/api-client.js"></script>
   <script src="app-core.js"></script>
   <script src="app-views.js"></script>
   <script src="app.js"></script>

--- a/public/frontend/api-client.js
+++ b/public/frontend/api-client.js
@@ -1,0 +1,67 @@
+(function () {
+  const createHeaders = (headersInit) => {
+    if (headersInit instanceof Headers) {
+      return new Headers(headersInit);
+    }
+    return new Headers(headersInit || {});
+  };
+
+  const request = (input, init = {}) => fetch(input, init);
+
+  const getJson = async (input, init = {}) => {
+    const response = await request(input, init);
+    const text = await response.text();
+    if (!text) {
+      return null;
+    }
+    return JSON.parse(text);
+  };
+
+  const postJson = (input, body, init = {}) => {
+    const headers = createHeaders(init.headers);
+    if (!headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    const nextInit = {
+      ...init,
+      method: init.method || "POST",
+      headers,
+      body: JSON.stringify(body ?? {})
+    };
+    return request(input, nextInit);
+  };
+
+  const applyAuth = (init = {}, tokenProvider) => {
+    const headers = createHeaders(init.headers);
+    const token = tokenProvider();
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+    return {
+      ...init,
+      headers
+    };
+  };
+
+  const ApiClient = {
+    request,
+    getJson,
+    postJson,
+    withAuth(tokenOrProvider) {
+      const provider = typeof tokenOrProvider === "function" ? tokenOrProvider : () => tokenOrProvider;
+      return {
+        request(input, init = {}) {
+          return request(input, applyAuth(init, provider));
+        },
+        getJson(input, init = {}) {
+          return getJson(input, applyAuth(init, provider));
+        },
+        postJson(input, body, init = {}) {
+          return postJson(input, body, applyAuth(init, provider));
+        }
+      };
+    }
+  };
+
+  window.ApiClient = ApiClient;
+})();


### PR DESCRIPTION
## Summary
- add a shared browser ApiClient helper and include it in the main page
- introduce AppStores with AuthStore/ProfileStore and update profile persistence through them
- gate routes by role, render a restricted placeholder, and use the ApiClient for publishing invitations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1d8620a88324b466bd8deeef5022