### PR TITLE
feat: add server-backed profile handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,12 @@
 
   document.addEventListener("DOMContentLoaded", () => {
     if (typeof App.init === "function") {
-      App.init();
+      const maybePromise = App.init();
+      if (maybePromise && typeof maybePromise.catch === "function") {
+        maybePromise.catch((error) => {
+          console.error("Не удалось инициализировать приложение", error);
+        });
+      }
     }
   });
 })();

--- a/prisma/migrations/0003_profile_autocreate/migration.sql
+++ b/prisma/migrations/0003_profile_autocreate/migration.sql
@@ -1,0 +1,90 @@
+-- Alter user role to enum and ensure safe defaults for profiles
+
+-- Create new enum type for user roles
+CREATE TYPE "UserRole" AS ENUM ('guest', 'wedding', 'contractor');
+
+-- Add temporary column with the new enum type
+ALTER TABLE "User"
+  ADD COLUMN "role_tmp" "UserRole" NOT NULL DEFAULT 'guest';
+
+-- Normalize existing role values into the enum set
+UPDATE "User"
+SET "role_tmp" = CASE
+  WHEN LOWER(COALESCE(NULLIF("role", ''), '')) = 'contractor' THEN 'contractor'::"UserRole"
+  WHEN LOWER(COALESCE(NULLIF("role", ''), '')) = 'wedding' THEN 'wedding'::"UserRole"
+  WHEN LOWER(COALESCE(NULLIF("role", ''), '')) = 'guest' THEN 'guest'::"UserRole"
+  ELSE 'guest'::"UserRole"
+END;
+
+-- Drop old column and rename the new one
+ALTER TABLE "User" DROP COLUMN "role";
+ALTER TABLE "User" RENAME COLUMN "role_tmp" TO "role";
+
+-- Ensure default is configured on the new column
+ALTER TABLE "User" ALTER COLUMN "role" SET DEFAULT 'guest';
+
+-- Ensure profile text columns have safe defaults
+ALTER TABLE "ContractorProfile" ALTER COLUMN "companyName" SET DEFAULT '';
+ALTER TABLE "WeddingProfile" ALTER COLUMN "coupleNames" SET DEFAULT '';
+
+-- Update existing data to respect the defaults
+UPDATE "ContractorProfile"
+SET "companyName" = COALESCE("companyName", '');
+
+UPDATE "WeddingProfile"
+SET "coupleNames" = COALESCE("coupleNames", '');
+
+-- Insert missing contractor profiles
+WITH normalized_users AS (
+  SELECT
+    "id",
+    CASE
+      WHEN "role" = 'contractor' THEN 'contractor'
+      WHEN "role" = 'wedding' THEN 'wedding'
+      ELSE 'guest'
+    END AS normalized_role
+  FROM "User"
+)
+INSERT INTO "ContractorProfile" ("id", "userId", "companyName", "description", "createdAt", "updatedAt")
+SELECT gen_random_uuid(), u."id", '', NULL, NOW(), NOW()
+FROM normalized_users u
+LEFT JOIN "ContractorProfile" cp ON cp."userId" = u."id"
+WHERE u.normalized_role = 'contractor'
+  AND cp."id" IS NULL;
+
+-- Insert missing wedding profiles (guest users receive a wedding profile by default)
+WITH normalized_users AS (
+  SELECT
+    "id",
+    CASE
+      WHEN "role" = 'contractor' THEN 'contractor'
+      WHEN "role" = 'wedding' THEN 'wedding'
+      ELSE 'guest'
+    END AS normalized_role
+  FROM "User"
+)
+INSERT INTO "WeddingProfile" ("id", "userId", "coupleNames", "eventDate", "location", "createdAt", "updatedAt")
+SELECT gen_random_uuid(), u."id", '', NULL, NULL, NOW(), NOW()
+FROM normalized_users u
+LEFT JOIN "WeddingProfile" wp ON wp."userId" = u."id"
+WHERE u.normalized_role IN ('wedding', 'guest')
+  AND wp."id" IS NULL;
+
+-- Support guidance:
+-- To backfill profiles manually for legacy accounts outside of migrations:
+--   const users = await prisma.user.findMany();
+--   await Promise.all(users.map(async (user) => {
+--     if (user.role === 'contractor') {
+--       await prisma.contractorProfile.upsert({
+--         where: { userId: user.id },
+--         update: {},
+--         create: { userId: user.id }
+--       });
+--     } else {
+--       await prisma.weddingProfile.upsert({
+--         where: { userId: user.id },
+--         update: {},
+--         create: { userId: user.id }
+--       });
+--     }
+--   }));

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,7 @@ model User {
   email              String?             @unique
   phone              String              @unique
   phoneConfirmed     Boolean             @default(false)
-  role               String              @default("guest")
+  role               UserRole            @default(guest)
   passwordHash       String
   refreshTokenHash   String?
   createdAt          DateTime            @default(now())
@@ -26,7 +26,7 @@ model ContractorProfile {
   id          String   @id @default(uuid())
   userId      String   @unique
   user        User     @relation(fields: [userId], references: [id])
-  companyName String
+  companyName String   @default("")
   description String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -36,7 +36,7 @@ model WeddingProfile {
   id            String   @id @default(uuid())
   userId        String   @unique
   user          User     @relation(fields: [userId], references: [id])
-  coupleNames   String
+  coupleNames   String   @default("")
   eventDate     DateTime?
   location      String?
   createdAt     DateTime @default(now())
@@ -69,4 +69,10 @@ model Guest {
 
   @@index([invitationId])
   @@index([weddingProfileId])
+}
+
+enum UserRole {
+  guest
+  wedding
+  contractor
 }

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -1,0 +1,198 @@
+const express = require('express');
+
+const { getPrismaClient } = require('../src/db/client');
+const config = require('../src/server/config');
+
+const router = express.Router();
+
+const prisma = config.databaseUrl ? getPrismaClient() : null;
+
+function ensurePrismaAvailable(res) {
+  if (!prisma) {
+    res.status(503).json({ error: 'База данных временно недоступна.' });
+    return false;
+  }
+  return true;
+}
+
+function sanitizeUser(user) {
+  if (!user) {
+    return null;
+  }
+  const {
+    passwordHash,
+    refreshTokenHash,
+    contractorProfile,
+    weddingProfile,
+    ...safeUser
+  } = user;
+  return safeUser;
+}
+
+function buildProfileResponse(user) {
+  if (!user) {
+    return null;
+  }
+  const contractorProfile = user.contractorProfile ?? null;
+  const weddingProfile = user.weddingProfile ?? null;
+  let activeProfile = null;
+  if (user.role === 'contractor') {
+    activeProfile = contractorProfile;
+  } else if (user.role === 'wedding') {
+    activeProfile = weddingProfile;
+  } else {
+    activeProfile = weddingProfile || contractorProfile || null;
+  }
+
+  return {
+    user: sanitizeUser(user),
+    profile: activeProfile,
+    contractorProfile,
+    weddingProfile
+  };
+}
+
+async function loadUserWithProfiles(userId) {
+  if (!prisma || !userId) {
+    return null;
+  }
+  return prisma.user.findUnique({
+    where: { id: userId },
+    include: {
+      contractorProfile: true,
+      weddingProfile: true
+    }
+  });
+}
+
+router.get('/', async (req, res) => {
+  if (!ensurePrismaAvailable(res)) {
+    return;
+  }
+
+  const userId = req.user?.sub;
+  if (!userId) {
+    return res.status(401).json({ error: 'Требуется авторизация.' });
+  }
+
+  try {
+    const user = await loadUserWithProfiles(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'Пользователь не найден.' });
+    }
+
+    return res.json(buildProfileResponse(user));
+  } catch (error) {
+    console.error('Не удалось получить профиль пользователя', error);
+    return res.status(500).json({ error: 'Не удалось получить профиль.' });
+  }
+});
+
+router.put('/', async (req, res) => {
+  if (!ensurePrismaAvailable(res)) {
+    return;
+  }
+
+  const userId = req.user?.sub;
+  if (!userId) {
+    return res.status(401).json({ error: 'Требуется авторизация.' });
+  }
+
+  const body = req.body || {};
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, role: true }
+    });
+
+    if (!user) {
+      return res.status(404).json({ error: 'Пользователь не найден.' });
+    }
+
+    if (user.role === 'contractor') {
+      const updateData = {};
+      if (Object.prototype.hasOwnProperty.call(body, 'companyName')) {
+        if (typeof body.companyName !== 'string') {
+          return res.status(400).json({ error: 'Название компании должно быть строкой.' });
+        }
+        updateData.companyName = body.companyName.trim();
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'description')) {
+        if (body.description !== null && typeof body.description !== 'string') {
+          return res.status(400).json({ error: 'Описание должно быть строкой или null.' });
+        }
+        if (typeof body.description === 'string') {
+          const trimmed = body.description.trim();
+          updateData.description = trimmed.length > 0 ? trimmed : null;
+        } else {
+          updateData.description = null;
+        }
+      }
+
+      await prisma.contractorProfile.upsert({
+        where: { userId },
+        update: updateData,
+        create: {
+          userId,
+          companyName: updateData.companyName ?? '',
+          description: updateData.description ?? null
+        }
+      });
+    } else {
+      const updateData = {};
+      if (Object.prototype.hasOwnProperty.call(body, 'coupleNames')) {
+        if (typeof body.coupleNames !== 'string') {
+          return res.status(400).json({ error: 'Имена пары должны быть строкой.' });
+        }
+        updateData.coupleNames = body.coupleNames.trim();
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'location')) {
+        if (body.location !== null && typeof body.location !== 'string') {
+          return res.status(400).json({ error: 'Локация должна быть строкой или null.' });
+        }
+        if (typeof body.location === 'string') {
+          updateData.location = body.location.trim();
+        } else {
+          updateData.location = null;
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'eventDate')) {
+        if (body.eventDate === null || body.eventDate === '') {
+          updateData.eventDate = null;
+        } else if (typeof body.eventDate === 'string' || body.eventDate instanceof Date) {
+          const parsed = new Date(body.eventDate);
+          if (Number.isNaN(parsed.getTime())) {
+            return res.status(400).json({ error: 'Неверный формат даты события.' });
+          }
+          updateData.eventDate = parsed;
+        } else {
+          return res.status(400).json({ error: 'Дата события должна быть строкой или null.' });
+        }
+      }
+
+      await prisma.weddingProfile.upsert({
+        where: { userId },
+        update: updateData,
+        create: {
+          userId,
+          coupleNames: updateData.coupleNames ?? '',
+          location: updateData.location ?? null,
+          eventDate: updateData.eventDate ?? null
+        }
+      });
+    }
+
+    const refreshedUser = await loadUserWithProfiles(userId);
+    if (!refreshedUser) {
+      return res.status(404).json({ error: 'Пользователь не найден.' });
+    }
+
+    return res.json(buildProfileResponse(refreshedUser));
+  } catch (error) {
+    console.error('Не удалось обновить профиль пользователя', error);
+    return res.status(500).json({ error: 'Не удалось обновить профиль.' });
+  }
+});
+
+module.exports = router;

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,16 @@ p {
   box-shadow: 0 10px 25px rgba(47, 42, 59, 0.08);
 }
 
+.profile-warning {
+  margin-bottom: 1.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: #fff4e5;
+  color: #7a4a00;
+  border: 1px solid rgba(231, 142, 46, 0.4);
+  font-size: 0.95rem;
+}
+
 .welcome {
   display: grid;
   gap: 2.5rem;


### PR DESCRIPTION
## Summary
- add a UserRole enum with safe defaults and a migration that backfills role-specific profiles
- create a profile REST router and ensure registration and auth flows create the correct empty profile inside a transaction
- synchronize the client profile store with server data, showing a warning when the database is unavailable

## Testing
- npm run prisma:migrate *(fails: prisma CLI missing in environment)*
- npm run prisma:generate *(fails: prisma CLI missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4350af008324a7b18b1ba1fb3b51